### PR TITLE
Fix readme url to go-sqlite3

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ the binary itself.
 
 The application currently only has one dependency:
 
-* [https://github.com/mattn/go-sqlite3](github.com/mattn/go-sqlite3)
+* [github.com/mattn/go-sqlite3](https://github.com/mattn/go-sqlite3)
 
 This can be installed using the following commands from the journal folder:
 


### PR DESCRIPTION
I think you inverted the markdown notation for the link :-)
I do the same mistake all the time !